### PR TITLE
fix: saber-plugin-image cant find styles when installed via yarn/npm

### DIFF
--- a/packages/saber-plugin-image/package.json
+++ b/packages/saber-plugin-image/package.json
@@ -4,8 +4,8 @@
   "main": "lib/index.js",
   "files": [
     "lib/index.js",
-    "lib/SaberImage.js",
-    "lib/saber-browser.js"
+    "lib/saber-browser.js",
+    "lib/styles.module.css"
   ],
   "license": "MIT",
   "dependencies": {

--- a/packages/saber-plugin-image/package.json
+++ b/packages/saber-plugin-image/package.json
@@ -3,9 +3,7 @@
   "version": "0.0.2",
   "main": "lib/index.js",
   "files": [
-    "lib/index.js",
-    "lib/saber-browser.js",
-    "lib/styles.module.css"
+    "lib/**"
   ],
   "license": "MIT",
   "dependencies": {

--- a/packages/saber-plugin-image/package.json
+++ b/packages/saber-plugin-image/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "main": "lib/index.js",
   "files": [
-    "lib/**"
+    "lib"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Currently, `saber-plugin-image` doesn't work when installed via yarn/npm, as `styles.module.css` is not included in `package.json`, resulting in a crash.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
