### PR TITLE
fix: add missing srcset attribute

### DIFF
--- a/packages/saber-plugin-image/lib/saber-browser.js
+++ b/packages/saber-plugin-image/lib/saber-browser.js
@@ -52,7 +52,7 @@ export default ({ Vue }) => {
         return h('img', {
           attrs: {
             ...$attrs,
-            'data-srcset': srcset,
+            srcset,
             width,
             height
           },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Adds the previously missing `srcset` attribute. `data-srcset` is not actually working for some reason, even though the `vue-lazyload` source code suggests it should. Related #196 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
