### PR TITLE
feat(saber-plugin-google-analytics): respect user's tracking preference

### DIFF
--- a/packages/saber-plugin-google-analytics/index.js
+++ b/packages/saber-plugin-google-analytics/index.js
@@ -4,11 +4,12 @@ const ID = 'google-analytics'
 
 exports.name = ID
 
-exports.apply = (api, { trackId = false } = {}) => {
+exports.apply = (api, { trackId = false, respectDoNotTrack = true } = {}) => {
   api.hooks.chainWebpack.tap(ID, config => {
     config.plugin('constants').tap(([options]) => [
       Object.assign(options, {
-        __GA_TRACK_ID__: JSON.stringify(trackId)
+        __GA_TRACK_ID__: JSON.stringify(trackId),
+        respectDoNotTrack
       })
     ])
   })

--- a/packages/saber-plugin-google-analytics/index.js
+++ b/packages/saber-plugin-google-analytics/index.js
@@ -4,12 +4,11 @@ const ID = 'google-analytics'
 
 exports.name = ID
 
-exports.apply = (api, { trackId = false, respectDoNotTrack = true } = {}) => {
+exports.apply = (api, { trackId = false } = {}) => {
   api.hooks.chainWebpack.tap(ID, config => {
     config.plugin('constants').tap(([options]) => [
       Object.assign(options, {
-        __GA_TRACK_ID__: JSON.stringify(trackId),
-        respectDoNotTrack
+        __GA_TRACK_ID__: JSON.stringify(trackId)
       })
     ])
   })

--- a/packages/saber-plugin-google-analytics/saber-browser.js
+++ b/packages/saber-plugin-google-analytics/saber-browser.js
@@ -2,7 +2,13 @@
 // Google analytics integration for Vue.js renderer
 export default function (ctx) {
   var router = ctx.router
-  if (process.browser && process.env.NODE_ENV === 'production' && __GA_TRACK_ID__) {
+  if (process.browser &&
+    process.env.NODE_ENV === 'production' &&
+    __GA_TRACK_ID__ &&
+    !(navigator.msDoNotTrack || // IE 9/10
+      window.doNotTrack || // IE 11
+      navigator.doNotTrack)
+  ) {
     (function (i, s, o, g, r, a, m) {
       i.GoogleAnalyticsObject = r
       i[r] = i[r] || function () {

--- a/packages/saber-plugin-google-analytics/saber-browser.js
+++ b/packages/saber-plugin-google-analytics/saber-browser.js
@@ -2,12 +2,8 @@
 // Google analytics integration for Vue.js renderer
 export default function (ctx) {
   var router = ctx.router
-  if (process.browser &&
-    process.env.NODE_ENV === 'production' &&
-    __GA_TRACK_ID__ &&
-    !(navigator.msDoNotTrack || // IE 9/10
-      window.doNotTrack || // IE 11
-      navigator.doNotTrack)
+  if (process.browser && process.env.NODE_ENV === 'production' && __GA_TRACK_ID__ &&
+    (!respectDoNotTrack || !(navigator.msDoNotTrack || window.doNotTrack || navigator.doNotTrack))
   ) {
     (function (i, s, o, g, r, a, m) {
       i.GoogleAnalyticsObject = r

--- a/packages/saber-plugin-google-analytics/saber-browser.js
+++ b/packages/saber-plugin-google-analytics/saber-browser.js
@@ -1,11 +1,29 @@
 /* eslint-disable */
 // Google analytics integration for Vue.js renderer
-export default function (ctx) {
-  var router = ctx.router
-  if (process.browser && process.env.NODE_ENV === 'production' && __GA_TRACK_ID__ &&
-    (!respectDoNotTrack || !(navigator.msDoNotTrack || window.doNotTrack || navigator.doNotTrack))
+export default function({ router }) {
+  if (
+    process.browser &&
+    process.env.NODE_ENV === 'production' &&
+    __GA_TRACK_ID__
   ) {
-    (function (i, s, o, g, r, a, m) {
+    function doNotTrackEnabled() {
+      const dntNumber = parseInt(
+        navigator.msDoNotTrack || // Internet Explorer 9 and 10 vendor prefix
+        window.doNotTrack || // IE 11 uses window.doNotTrack
+          navigator.doNotTrack, // W3C
+        10
+      )
+
+      return dntNumber === 1
+    }
+
+    if (doNotTrackEnabled()) {
+      // Respect doNotTrack setting
+      return
+    }
+
+    // prettier-ignore
+    ;(function(i, s, o, g, r, a, m) {
       i.GoogleAnalyticsObject = r
       i[r] = i[r] || function () {
         (i[r].q = i[r].q || []).push(arguments)
@@ -21,7 +39,7 @@ export default function (ctx) {
     ga('create', __GA_TRACK_ID__, 'auto')
     ga('send', 'pageview')
 
-    router.afterEach(function (to) {
+    router.afterEach(to => {
       ga('set', 'page', to.fullPath)
       ga('send', 'pageview')
     })


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Add a `respectDoNotTrack` (Default: `true`) option for `saber-plugin-google-analytics` plugin to respect browser's "Do Not Track" setting. When "Do Not Track" is enabled, the plugin won't load analytics script.

The feature is not supported by official analytics.js, but libraries such as [ga-lite](https://github.com/jehna/ga-lite/blob/master/src/do-not-track-enabled.js) does.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
