### PR TITLE
feat: add support to line numbers in markdown

### DIFF
--- a/packages/saber-highlight-css/default.css
+++ b/packages/saber-highlight-css/default.css
@@ -61,27 +61,16 @@
 }
 
 /* Line numbers */
-.saber-highlight.has-line-numbers .saber-highlight-mask,
-.saber-highlight.has-line-numbers .saber-highlight-code {
-  padding-left: 3.8rem !important;
-}
-
-.saber-highlight.has-line-numbers .saber-highlight-code code {
-  position: relative;
-}
-
 .saber-highlight-line-numbers {
-  position: absolute;
   pointer-events: none;
-  top: 0;
   font-size: 100%;
-  left: -3.8rem;
-  width: 3rem;
+  float: left;
   letter-spacing: -1px;
   border-right: 1px solid #999;
   user-select: none;
   text-align: right;
   padding-right: 0.8rem;
+  margin-right: .8rem;
   counter-reset: linenumber;
 }
 
@@ -94,8 +83,4 @@
   content: counter(linenumber);
   color: #999;
   display: block;
-}
-
-.saber-highlight.has-line-numbers .code-line.highlighted {
-  margin-left: -3.8rem;
 }

--- a/packages/saber-highlight-css/default.css
+++ b/packages/saber-highlight-css/default.css
@@ -57,5 +57,10 @@
 
 .code-line.highlighted {
   background: rgba(3, 169, 244, 0.121);
-  box-shadow: inset 2px 0 0 0 rgba(3, 169, 244, 0.278)
+}
+
+.saber-highlight-line-numbers {
+  float: left;
+  text-align: right;
+  margin-right: 5px;
 }

--- a/packages/saber-highlight-css/default.css
+++ b/packages/saber-highlight-css/default.css
@@ -11,11 +11,12 @@
   position: absolute;
   right: 10px;
   top: 5px;
-  font-size: .75rem;
+  font-size: 0.75rem;
   color: #bdc5d1;
 }
 
-.saber-highlight-mask, .saber-highlight-code {
+.saber-highlight-mask,
+.saber-highlight-code {
   line-height: 1.5;
   background-color: transparent !important;
   text-shadow: none !important;
@@ -52,15 +53,49 @@
 
 .saber-highlight-code code,
 .saber-highlight-mask {
-  font-size: .875rem;
+  font-size: 0.875rem;
 }
 
 .code-line.highlighted {
   background: rgba(3, 169, 244, 0.121);
 }
 
+/* Line numbers */
+.saber-highlight.has-line-numbers .saber-highlight-mask,
+.saber-highlight.has-line-numbers .saber-highlight-code {
+  padding-left: 3.8rem !important;
+}
+
+.saber-highlight.has-line-numbers .saber-highlight-code code {
+  position: relative;
+}
+
 .saber-highlight-line-numbers {
-  float: left;
+  position: absolute;
+  pointer-events: none;
+  top: 0;
+  font-size: 100%;
+  left: -3.8rem;
+  width: 3rem;
+  letter-spacing: -1px;
+  border-right: 1px solid #999;
+  user-select: none;
   text-align: right;
-  margin-right: 5px;
+  padding-right: 0.8rem;
+  counter-reset: linenumber;
+}
+
+.saber-highlight-line-numbers > span {
+  counter-increment: linenumber;
+  display: block;
+}
+
+.saber-highlight-line-numbers > span:before {
+  content: counter(linenumber);
+  color: #999;
+  display: block;
+}
+
+.saber-highlight.has-line-numbers .code-line.highlighted {
+  margin-left: -3.8rem;
 }

--- a/packages/saber/lib/markdown/__test__/__snapshots__/highlight-plugin.test.js.snap
+++ b/packages/saber/lib/markdown/__test__/__snapshots__/highlight-plugin.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`code block markdown.lineNumbers = true 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')<span aria-label=\\"hidden\\" class=\\"saber-highlight-line-numbers\\"><span></span></span></code></pre></div>"`;
+exports[`code block markdown.lineNumbers = true 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')<span aria-hidden=\\"true\\" class=\\"saber-highlight-line-numbers\\"><span></span></span></code></pre></div>"`;
 
-exports[`code block with {lineNumbers:true} 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')<span aria-label=\\"hidden\\" class=\\"saber-highlight-line-numbers\\"><span></span></span></code></pre></div>"`;
+exports[`code block with {lineNumbers:true} 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')<span aria-hidden=\\"true\\" class=\\"saber-highlight-line-numbers\\"><span></span></span></code></pre></div>"`;
 
 exports[`main 1`] = `"<div class=\\"saber-highlight\\" v-pre=\\"\\" data-lang=\\"vue\\"><pre class=\\"saber-highlight-code language-vue\\"><code class=\\"language-vue\\">&lt;div&gt;hehe&lt;/div&gt;</code></pre></div>"`;

--- a/packages/saber/lib/markdown/__test__/__snapshots__/highlight-plugin.test.js.snap
+++ b/packages/saber/lib/markdown/__test__/__snapshots__/highlight-plugin.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`code block markdown.lineNumbers = true 1`] = `"<div class=\\"saber-highlight\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"saber-highlight-line-numbers\\"><span class=\\"token\\">1</span></code><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')</code></pre></div>"`;
+exports[`code block markdown.lineNumbers = true 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')<span aria-label=\\"hidden\\" class=\\"saber-highlight-line-numbers\\"><span></span></span></code></pre></div>"`;
 
-exports[`code block with {lineNumbers:true} 1`] = `"<div class=\\"saber-highlight\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"saber-highlight-line-numbers\\"><span class=\\"token\\">1</span></code><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')</code></pre></div>"`;
+exports[`code block with {lineNumbers:true} 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')<span aria-label=\\"hidden\\" class=\\"saber-highlight-line-numbers\\"><span></span></span></code></pre></div>"`;
 
 exports[`main 1`] = `"<div class=\\"saber-highlight\\" v-pre=\\"\\" data-lang=\\"vue\\"><pre class=\\"saber-highlight-code language-vue\\"><code class=\\"language-vue\\">&lt;div&gt;hehe&lt;/div&gt;</code></pre></div>"`;

--- a/packages/saber/lib/markdown/__test__/__snapshots__/highlight-plugin.test.js.snap
+++ b/packages/saber/lib/markdown/__test__/__snapshots__/highlight-plugin.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`code block markdown.lineNumbers = true 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')<span aria-hidden=\\"true\\" class=\\"saber-highlight-line-numbers\\"><span></span></span></code></pre></div>"`;
+exports[`code block markdown.lineNumbers = true 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\"><span aria-hidden=\\"true\\" class=\\"saber-highlight-line-numbers\\"><span></span></span>const cry = Array(3).fill('ora').join(' ')</code></pre></div>"`;
 
-exports[`code block with {lineNumbers:true} 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')<span aria-hidden=\\"true\\" class=\\"saber-highlight-line-numbers\\"><span></span></span></code></pre></div>"`;
+exports[`code block with {lineNumbers:true} 1`] = `"<div class=\\"saber-highlight has-line-numbers\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"language-js\\"><span aria-hidden=\\"true\\" class=\\"saber-highlight-line-numbers\\"><span></span></span>const cry = Array(3).fill('ora').join(' ')</code></pre></div>"`;
 
 exports[`main 1`] = `"<div class=\\"saber-highlight\\" v-pre=\\"\\" data-lang=\\"vue\\"><pre class=\\"saber-highlight-code language-vue\\"><code class=\\"language-vue\\">&lt;div&gt;hehe&lt;/div&gt;</code></pre></div>"`;

--- a/packages/saber/lib/markdown/__test__/__snapshots__/highlight-plugin.test.js.snap
+++ b/packages/saber/lib/markdown/__test__/__snapshots__/highlight-plugin.test.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`code block markdown.lineNumbers = true 1`] = `"<div class=\\"saber-highlight\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"saber-highlight-line-numbers\\"><span class=\\"token\\">1</span></code><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')</code></pre></div>"`;
+
+exports[`code block with {lineNumbers:true} 1`] = `"<div class=\\"saber-highlight\\" v-pre=\\"\\" data-lang=\\"js\\"><pre class=\\"saber-highlight-code language-js\\"><code class=\\"saber-highlight-line-numbers\\"><span class=\\"token\\">1</span></code><code class=\\"language-js\\">const cry = Array(3).fill('ora').join(' ')</code></pre></div>"`;
+
 exports[`main 1`] = `"<div class=\\"saber-highlight\\" v-pre=\\"\\" data-lang=\\"vue\\"><pre class=\\"saber-highlight-code language-vue\\"><code class=\\"language-vue\\">&lt;div&gt;hehe&lt;/div&gt;</code></pre></div>"`;

--- a/packages/saber/lib/markdown/__test__/highlight-plugin.test.js
+++ b/packages/saber/lib/markdown/__test__/highlight-plugin.test.js
@@ -16,3 +16,33 @@ test('main', () => {
   )
   expect(html).toMatchSnapshot()
 })
+
+test('code block with {lineNumbers:true}', () => {
+  const md = new Markdown()
+  const { env } = createEnv()
+  md.use(fenceOptionsPlugin)
+  const html = md.render(
+    `
+\`\`\`js {lineNumbers:true}
+const cry = Array(3).fill('ora').join(' ')
+\`\`\`
+  `,
+    env
+  )
+  expect(html).toMatchSnapshot()
+})
+
+test('code block markdown.lineNumbers = true', () => {
+  const md = new Markdown()
+  const { env } = createEnv()
+  md.use(fenceOptionsPlugin, { lineNumbers: true })
+  const html = md.render(
+    `
+\`\`\`js {lineNumbers:true}
+const cry = Array(3).fill('ora').join(' ')
+\`\`\`
+  `,
+    env
+  )
+  expect(html).toMatchSnapshot()
+})

--- a/packages/saber/lib/markdown/highlight-plugin.js
+++ b/packages/saber/lib/markdown/highlight-plugin.js
@@ -1,19 +1,23 @@
 const RE = /\s*{([^}]+)}/
 
 const parseOptions = str => {
+  if (!RE.test(str)) {
+    return {}
+  }
+
   const [, options] = RE.exec(str)
   const fn = new Function(`return {${options}}`) // eslint-disable-line no-new-func
   return fn()
 }
 
 const generateLineNumbers = code =>
-  '<code class="saber-highlight-line-numbers">' +
+  '<span aria-label="hidden" class="saber-highlight-line-numbers">' +
   code
     .trim()
     .split('\n')
-    .map((lineHtml, i) => `<span class="token">${i + 1}</span>`)
-    .join('\n') +
-  '</code>'
+    .map(() => `<span></span>`)
+    .join('') +
+  '</span>'
 
 module.exports = (
   md,
@@ -27,65 +31,26 @@ module.exports = (
     codeMask = '',
     lines = ''
   }) =>
-    `<div${preWrapperAttrs}>${codeMask}<pre${preAttrs}>${lines}<code${codeAttrs}>${code.trim()}</code></pre></div>`
+    `<div${preWrapperAttrs}>${codeMask}<pre${preAttrs}><code${codeAttrs}>${code.trim()}${lines}</code></pre></div>`
 
   md.renderer.rules.fence = (...args) => {
     const [tokens, idx, options, env, self] = args
     const token = tokens[idx]
 
+    const fenceOptions = parseOptions(token.info)
     const langName = token.info.replace(RE, '').trim()
+    const langClass = `language-${langName || 'text'}`
+    token.info = langName
 
     const code = options.highlight
       ? options.highlight(token.content, langName, env)
       : md.utils.escapeHtml(token.content)
 
-    const renderAttrs = attrs => self.renderAttrs({ attrs })
-
-    const langClass = `language-${langName || 'text'}`
-    const preAttrs = renderAttrs([
-      ...(token.attrs || []),
-      ['class', ['saber-highlight-code', langClass].filter(Boolean).join(' ')]
-    ])
-    const codeAttrs = renderAttrs([
-      ...(token.attrs || []),
-      ['class', langClass]
-    ])
-    const preWrapperAttrs = renderAttrs([
-      ['class', 'saber-highlight'],
-      ['v-pre', ''],
-      ['data-lang', langName]
-    ])
-
-    if (!token.info || !RE.test(token.info)) {
-      // Generate lines if global markdown.lineNumbers is true
-      const lines = lineNumbers ? generateLineNumbers(code) : ''
-
-      return renderPreWrapper({
-        preWrapperAttrs,
-        preAttrs,
-        codeAttrs,
-        code,
-        lines
-      })
-    }
-
-    const fenceOptions = parseOptions(token.info)
     const highlightLines = fenceOptions.highlightLines
       ? fenceOptions.highlightLines.map(v =>
           `${v}`.split('-').map(v => parseInt(v, 10))
         )
       : []
-
-    token.info = langName
-
-    const shouldGenerateLineNumbers =
-      // It might be false so check for undefined
-      fenceOptions.lineNumbers === undefined
-        ? // Defaults to global config
-          lineNumbers
-        : // If it's set to false, even if the global config says true, ignore
-          fenceOptions.lineNumbers
-    const lines = shouldGenerateLineNumbers ? generateLineNumbers(code) : ''
 
     const codeMask =
       highlightLines.length === 0
@@ -117,6 +82,33 @@ module.exports = (
             })
             .join('') +
           '</div>'
+
+    const renderAttrs = attrs => self.renderAttrs({ attrs })
+    const shouldGenerateLineNumbers =
+      // It might be false so check for undefined
+      fenceOptions.lineNumbers === undefined
+        ? // Defaults to global config
+          lineNumbers
+        : // If it's set to false, even if the global config says true, ignore
+          fenceOptions.lineNumbers
+    const lines = shouldGenerateLineNumbers ? generateLineNumbers(code) : ''
+
+    const preAttrs = renderAttrs([
+      ...(token.attrs || []),
+      ['class', ['saber-highlight-code', langClass].filter(Boolean).join(' ')]
+    ])
+    const codeAttrs = renderAttrs([
+      ...(token.attrs || []),
+      ['class', langClass]
+    ])
+    const preWrapperAttrs = renderAttrs([
+      [
+        'class',
+        `saber-highlight${shouldGenerateLineNumbers ? ' has-line-numbers' : ''}`
+      ],
+      ['v-pre', ''],
+      ['data-lang', langName]
+    ])
 
     return renderPreWrapper({
       preWrapperAttrs,

--- a/packages/saber/lib/markdown/highlight-plugin.js
+++ b/packages/saber/lib/markdown/highlight-plugin.js
@@ -31,7 +31,7 @@ module.exports = (
     codeMask = '',
     lines = ''
   }) =>
-    `<div${preWrapperAttrs}>${codeMask}<pre${preAttrs}><code${codeAttrs}>${code.trim()}${lines}</code></pre></div>`
+    `<div${preWrapperAttrs}>${codeMask}<pre${preAttrs}><code${codeAttrs}>${lines}${code.trim()}</code></pre></div>`
 
   md.renderer.rules.fence = (...args) => {
     const [tokens, idx, options, env, self] = args

--- a/packages/saber/lib/markdown/highlight-plugin.js
+++ b/packages/saber/lib/markdown/highlight-plugin.js
@@ -11,7 +11,7 @@ const parseOptions = str => {
 }
 
 const generateLineNumbers = code =>
-  '<span aria-label="hidden" class="saber-highlight-line-numbers">' +
+  '<span aria-hidden="true" class="saber-highlight-line-numbers">' +
   code
     .trim()
     .split('\n')

--- a/packages/saber/lib/plugins/transformer-markdown.js
+++ b/packages/saber/lib/plugins/transformer-markdown.js
@@ -77,7 +77,10 @@ function transformMarkdown(api, page) {
     },
     {
       name: 'highlight',
-      resolve: require.resolve('../markdown/highlight-plugin')
+      resolve: require.resolve('../markdown/highlight-plugin'),
+      options: {
+        lineNumbers: markdown.lineNumbers
+      }
     },
     {
       name: 'link',

--- a/packages/saber/lib/utils/validateConfig.js
+++ b/packages/saber/lib/utils/validateConfig.js
@@ -36,6 +36,7 @@ module.exports = (config, { dev }) => {
       options: 'object?',
       headings: 'object?',
       highlighter: 'string?',
+      lineNumbers: 'boolean?',
       // Same as the type of Saber plugins
       plugins
     },

--- a/website/pages/docs/markdown-features.md
+++ b/website/pages/docs/markdown-features.md
@@ -276,6 +276,54 @@ If you want to override the font size or font family, you need to add CSS for bo
 }
 ```
 
+### Line Number in Code Blocks
+
+Input:
+
+````markdown
+```js {lineNumbers:true}
+[
+  {
+    text: 'A page',
+    slug: 'a-page',
+    level: 1
+  },
+  {
+    text: 'A section',
+    slug: 'a-section',
+    level: 2
+  },
+  {
+    text: 'Another section',
+    slug: 'another-section',
+    level: 3
+  }
+]
+```
+````
+
+Output:
+
+```js {lineNumbers:true}
+[
+  {
+    text: 'A page',
+    slug: 'a-page',
+    level: 1
+  },
+  {
+    text: 'A section',
+    slug: 'a-section',
+    level: 2
+  },
+  {
+    text: 'Another section',
+    slug: 'another-section',
+    level: 3
+  }
+]
+```
+
 ## Configure markdown-it
 
 Check out [markdown.options](./saber-config.md#options) for setting markdown-it options and [markdown.plugins](./saber-config.md#plugins-2) for adding markdown-it plugins.

--- a/website/pages/docs/markdown-features.md
+++ b/website/pages/docs/markdown-features.md
@@ -276,12 +276,12 @@ If you want to override the font size or font family, you need to add CSS for bo
 }
 ```
 
-### Line Number in Code Blocks
+### Line Numbers in Code Blocks
 
 Input:
 
 ````markdown
-```js {lineNumbers:true}
+```js {lineNumbers:true,highlightLines:['2-5']}
 [
   {
     text: 'A page',
@@ -304,7 +304,7 @@ Input:
 
 Output:
 
-```js {lineNumbers:true}
+```js {lineNumbers:true,highlightLines:['2-5']}
 [
   {
     text: 'A page',

--- a/website/pages/docs/saber-config.md
+++ b/website/pages/docs/saber-config.md
@@ -167,6 +167,13 @@ interface MarkdownPlugin {
 }
 ```
 
+### lineNumbers
+
+- Type: `boolean`
+- Default: `false`
+
+Always show line numbers in code blocks.
+
 ## permalinks
 
 - Type: `Permalinks` `(page: Page) => Permalinks`

--- a/website/pages/docs/saber-config.md
+++ b/website/pages/docs/saber-config.md
@@ -172,7 +172,7 @@ interface MarkdownPlugin {
 - Type: `boolean`
 - Default: `false`
 
-Always show line numbers in code blocks.
+Show line numbers in code blocks.
 
 ## permalinks
 


### PR DESCRIPTION
* highlight-plugin.js now read global and local { lineNumber: true}.
* Added tests and snapshots for the feature.
* Receive and validate lineNumber from markdown settings.
* Add some CSS for the line numbers.
* Document both the markdown config and the inline option.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Before**
![image](https://user-images.githubusercontent.com/9121359/58527422-ecde6f00-81a8-11e9-8a36-c8c5a6bf407a.png)

**After**
![image](https://user-images.githubusercontent.com/9121359/58527387-c7e9fc00-81a8-11e9-96df-002c3e035bc0.png)


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [x] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Tried to keep CSS at minimum to maintain the feel of the current styles.

Had to change `renderPreWrapper` (packages/saber/lib/markdown/highlight-plugin.js) signature since xo limits arguments to 4.

Took minor edits over `highlightLines` (packages/saber/lib/markdown/highlight-plugin.js) since the current implementation assumed it was the only option.

Hopefully my edits on the docs are to your liking.