### PR TITLE
fix(saber-highlighter-prism): add aliases for some languages

### DIFF
--- a/packages/saber-highlighter-prism/index.js
+++ b/packages/saber-highlighter-prism/index.js
@@ -3,9 +3,9 @@ const { log } = require('saber-log')
 const loadLanguages = require('./loadLanguages')
 
 const languageAlias = {
-  'vue': 'html',
-  'sh': 'bash',
-  'styl': 'stylus',
+  vue: 'html',
+  sh: 'bash',
+  styl: 'stylus'
 }
 
 module.exports = (code, lang) => {

--- a/packages/saber-highlighter-prism/index.js
+++ b/packages/saber-highlighter-prism/index.js
@@ -2,13 +2,19 @@ const Prism = require('prismjs')
 const { log } = require('saber-log')
 const loadLanguages = require('./loadLanguages')
 
+const languageAlias = {
+  'vue': 'html',
+  'sh': 'bash',
+  'styl': 'stylus',
+}
+
 module.exports = (code, lang) => {
   if (!lang) return Prism.highlight(code, {})
 
   lang = lang.toLowerCase()
 
-  if (lang === 'vue') {
-    lang = 'html'
+  if (lang in languageAlias) {
+    lang = languageAlias[lang]
   }
 
   if (!Prism.languages[lang]) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Add aliases for `bash` and `stylus`.

According to the docs of Prismjs:
![image](https://user-images.githubusercontent.com/18205362/58529600-11b8fd80-820e-11e9-8f58-592dc802d0e7.png)
![image](https://user-images.githubusercontent.com/18205362/58529602-17164800-820e-11e9-8d57-033848246c5f.png)

