### PR TITLE
Fix #250: Ensure consistent documentation sidebar widths.

### DIFF
--- a/packages/saber-utils/package.json
+++ b/packages/saber-utils/package.json
@@ -17,6 +17,5 @@
     "fast-glob": "2.2.6",
     "fs-extra": "7.0.1"
   },
-  "license": "MIT",
-  "xo": false
+  "license": "MIT"
 }

--- a/packages/saber-utils/package.json
+++ b/packages/saber-utils/package.json
@@ -17,5 +17,6 @@
     "fast-glob": "2.2.6",
     "fs-extra": "7.0.1"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "xo": false
 }

--- a/website/src/css/global.css
+++ b/website/src/css/global.css
@@ -70,7 +70,6 @@ a {
 }
 
 .content {
-  flex: 1 1 0%;
   padding-left: 60px;
   padding-right: 60px;
   width: 100%;

--- a/website/src/css/global.css
+++ b/website/src/css/global.css
@@ -75,6 +75,7 @@ a {
   width: 100%;
   max-width: 760px;
   margin: 0 auto;
+  overflow: auto;
 
   @media (max-width: 768px) {
     padding-left: 0;
@@ -86,8 +87,9 @@ a {
 .rightbar {
   width: var(--rightbar-width);
   font-size: 14px;
+  word-break: break-word;
 
-  @media (max-width: 768px) {
+  @media (max-width: 1024px) {
     display: none;
   }
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The documentation `.content` is currently set to `flex-grow: 1`, which interferes with the predefined sidebar widths. Removing this, and tweaking some overflow settings should resolve #250.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
