### PR TITLE
Fix #204, adding API for rendering page content

### DIFF
--- a/packages/saber-plugin-feed/example/pages/_posts/hello-world.md
+++ b/packages/saber-plugin-feed/example/pages/_posts/hello-world.md
@@ -4,4 +4,4 @@ date: 2018-02-12
 layout: post
 ---
 
-wtf is __this__
+wtf is __this__ {{ 1 + 1 }}

--- a/packages/saber-plugin-feed/lib/index.js
+++ b/packages/saber-plugin-feed/lib/index.js
@@ -48,30 +48,36 @@ exports.apply = (api, options = {}) => {
   async function generateFeed(localePath) {
     // Prepare posts
     const posts = []
-    for (const page of api.pages.values()) {
-      if (page.attributes.type !== 'post' || page.attributes.draft) {
-        continue
-      }
 
-      const matchedLocalePath = api.pages.getMatchedLocalePath(
-        page.attributes.permalink
-      )
-      if (localePath !== matchedLocalePath) {
-        continue
-      }
+    await Promise.all(
+      [...api.pages.values()].map(async page => {
+        if (page.attributes.type !== 'post' || page.attributes.draft) {
+          return
+        }
 
-      const { excerpt } = page.attributes
-      posts.push({
-        title: page.attributes.title,
-        id: page.attributes.permalink,
-        link: resolveURL(siteConfig.url, page.attributes.permalink),
-        // Strip HTML tags in excerpt and use it as description (a.k.a. summary)
-        description: excerpt && excerpt.replace(/<(?:.|\n)*?>/gm, ''),
-        content: page.content,
-        date: page.attributes.updatedAt,
-        published: page.attributes.createdAt
+        const matchedLocalePath = api.pages.getMatchedLocalePath(
+          page.attributes.permalink
+        )
+        if (localePath !== matchedLocalePath) {
+          return
+        }
+
+        const content = await api.renderer.renderPageContent(
+          page.attributes.permalink
+        )
+        const { excerpt } = page.attributes
+        posts.push({
+          title: page.attributes.title,
+          id: page.attributes.permalink,
+          link: resolveURL(siteConfig.url, page.attributes.permalink),
+          // Strip HTML tags in excerpt and use it as description (a.k.a. summary)
+          description: excerpt && excerpt.replace(/<(?:.|\n)*?>/gm, ''),
+          content,
+          date: page.attributes.updatedAt,
+          published: page.attributes.createdAt
+        })
       })
-    }
+    )
 
     // Order by published
     const items = posts

--- a/packages/saber-plugin-feed/lib/index.js
+++ b/packages/saber-plugin-feed/lib/index.js
@@ -70,7 +70,8 @@ exports.apply = (api, options = {}) => {
           id: page.attributes.permalink,
           link: resolveURL(siteConfig.url, page.attributes.permalink),
           // Strip HTML tags in excerpt and use it as description (a.k.a. summary)
-          description: page.excerpt && page.excerpt.replace(/<(?:.|\n)*?>/gm, ''),
+          description:
+            page.excerpt && page.excerpt.replace(/<(?:.|\n)*?>/gm, ''),
           content,
           date: page.attributes.updatedAt,
           published: page.attributes.createdAt

--- a/packages/saber/vue-renderer/app/components/LayoutManager.vue
+++ b/packages/saber/vue-renderer/app/components/LayoutManager.vue
@@ -17,11 +17,26 @@ export default {
 
     const attrs = { props: { page } }
 
+    const wrapSlot = slot => {
+      const { markPageContent } = parent.$ssrContext || {}
+      if (markPageContent) {
+        const result = h('div', null, [markPageContent[0]].concat(slot, markPageContent[1]))
+        return Array.isArray(slot)? [result] : result
+      }
+      return slot
+    }
+
     if (typeof layout !== 'string') {
-      return componentSlot ? componentSlot(attrs.props) : h('div', {
-        ...attrs,
-        class: '_saber-page'
-      }, defaultSlot ? defaultSlot() : undefined)
+      return componentSlot
+        ? wrapSlot(componentSlot(attrs.props))
+        : h(
+            'div',
+            {
+              ...attrs,
+              class: '_saber-page'
+            },
+            wrapSlot(defaultSlot ? defaultSlot() : undefined)
+          )
     }
 
     const LayoutComponent = layouts[layout] || layouts.default
@@ -30,7 +45,17 @@ export default {
       console.error(`Cannot find layout component "${layout}" in `, layouts)
     }
 
-    return h(LayoutComponent, attrs, componentSlot ? componentSlot(attrs.props) : defaultSlot ? defaultSlot() : undefined)
+    return h(
+      LayoutComponent,
+      attrs,
+      wrapSlot(
+        componentSlot
+          ? componentSlot(attrs.props)
+          : defaultSlot
+          ? defaultSlot()
+          : undefined
+      )
+    )
   }
 }
 </script>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Closes #204 

Given page `/`:

```markdown
calculate __1+1__: {{ 1 + 1 }}
```

With API: `api.renderer.renderPageContent('/')` you get:

```html
calculate <strong>1+1</strong>: 2
```

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Canary Versions</summary>
 - `extract-sfc-blocks@0.0.3-canary.268.dce375b.0`
 - `create-blog@0.2.7-canary.268.dce375b.0`
 - `create-site@0.3.1-canary.268.dce375b.0`
 - `saber-highlight-css@0.0.6-canary.268.dce375b.0`
 - `saber-highlighter-prism@0.3.2-canary.268.dce375b.0`
 - `saber-log@0.2.1-canary.268.dce375b.0`
 - `saber-markdown@0.0.9-canary.268.dce375b.0`
 - `saber-plugin-feed@0.3.4-canary.268.dce375b.0`
 - `saber-plugin-git-modification-time@0.0.4-canary.268.dce375b.0`
 - `saber-plugin-google-analytics@0.0.7-canary.268.dce375b.0`
 - `saber-plugin-image@0.0.5-canary.268.dce375b.0`
 - `saber-plugin-meta-redirect@0.0.6-canary.268.dce375b.0`
 - `saber-plugin-netlify-redirect@0.0.7-canary.268.dce375b.0`
 - `saber-plugin-prismjs@0.2.2-canary.268.dce375b.0`
 - `saber-plugin-pwa@0.3.4-canary.268.dce375b.0`
 - `saber-plugin-query-posts@0.3.3-canary.268.dce375b.0`
 - `saber-plugin-transformer-html@0.0.6-canary.268.dce375b.0`
 - `saber-plugin-transformer-pug@0.0.6-canary.268.dce375b.0`
 - `saber-utils@0.1.5-canary.268.dce375b.0`
 - `saber@0.6.9-canary.268.dce375b.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
