### PR TITLE
fix(markdown): Don't assume link_open relative position

### DIFF
--- a/packages/saber/lib/markdown/__test__/link-plugin.test.js
+++ b/packages/saber/lib/markdown/__test__/link-plugin.test.js
@@ -1,0 +1,22 @@
+const Markdown = require('saber-markdown')
+const linkPlugin = require('../link-plugin')
+const createEnv = require('./create-env')
+
+test('simple', () => {
+  const md = new Markdown()
+  const { env } = createEnv()
+  md.use(linkPlugin)
+  const html = md.render(
+    `
+[ \`link c\` ](https://c)
+[ \`link a\` ](a)
+[ \`link b\` ](b)
+  `,
+    env
+  )
+  expect(html)
+    .toBe(`<p><a href="https://c" target="_blank" rel="noopener noreferrer"> <code>link c</code> </a>
+<saber-link to="a"> <code>link a</code> </saber-link>
+<saber-link to="b"> <code>link b</code> </saber-link></p>
+`)
+})

--- a/packages/saber/lib/markdown/link-plugin.js
+++ b/packages/saber/lib/markdown/link-plugin.js
@@ -46,7 +46,7 @@ module.exports = function(md) {
   }
 
   md.renderer.rules.link_close = (tokens, idx, options, env, self) => {
-    const openToken = tokens[idx - 2]
+    const openToken = tokens.find(token => token.type === 'link_open')
     const token = tokens[idx]
     const prefix = ''
     if (openToken) {

--- a/packages/saber/lib/markdown/link-plugin.js
+++ b/packages/saber/lib/markdown/link-plugin.js
@@ -46,7 +46,15 @@ module.exports = function(md) {
   }
 
   md.renderer.rules.link_close = (tokens, idx, options, env, self) => {
-    const openToken = tokens.find(token => token.type === 'link_open')
+    // Find the closest `link_open` token
+    let openToken
+    for (let i = idx - 1; i--; i > 0) {
+      if (tokens[i].type === 'link_open') {
+        openToken = tokens[i]
+        break
+      }
+    }
+
     const token = tokens[idx]
     const prefix = ''
     if (openToken) {

--- a/packages/saber/lib/markdown/link-plugin.js
+++ b/packages/saber/lib/markdown/link-plugin.js
@@ -48,7 +48,7 @@ module.exports = function(md) {
   md.renderer.rules.link_close = (tokens, idx, options, env, self) => {
     // Find the closest `link_open` token
     let openToken
-    for (let i = idx - 1; i--; i > 0) {
+    for (let i = idx - 1; ; i--) {
       if (tokens[i].type === 'link_open') {
         openToken = tokens[i]
         break


### PR DESCRIPTION
Closes #277

Currently the saber-link render assumes the token for a link_open
token will always be two tokens before the link_close. Altough it holds
true for most of the cases, sometimes it might not such as inline code
inside the link text.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
