### PR TITLE
add: included static folder favicon docs

### DIFF
--- a/website/pages/docs/static-folder.md
+++ b/website/pages/docs/static-folder.md
@@ -15,6 +15,10 @@ However, there is an **escape hatch** that you can use to add an asset outside o
 
 You can create a folder named `static` at the root of your project or your theme directory. Every file you put into that folder will be copied into the `public` folder. E.g. if you add a file named `sun.jpg` to the static folder, it’ll be copied to `public/sun.jpg`
 
+### Adding Favicon to your Saber site
+
+The static folder can also contain your site's `favicon.ico`. When your site is rendered, like all assets inside the `static` folder, it will also be copied to the `public/` folder. The favicon can also be manipulated per component by [setting it in the `head` property](https://saber.land/docs/manipulating-head.html#customize-ltheadgt-per-component) on a given page.
+
 ### Referencing your static asset
 
 You can reference assets from the `static` folder in your code with absolute path, i.e. starting with a slash `/`.


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Thanks to the saber core team and contributors for such an awesome tool. I love working with it.

The motivation behind this pull request is to fill in a small missing piece of the saber docs on how to globally update the saber site's favicon by including it in the `static` folder. One would go about it perhaps by [setting it in the `head` options](https://saber.land/docs/manipulating-head.html#customize-ltheadgt-per-component) in every component. But this can be quite taxing for users. I faced this problem and the solution was somewhat simple. I was able to get around it by asking the saber team and they mentioned to make use of the `static` folder for public assets. So I thought to include this in the docs for coming users!

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
