### PR TITLE
fix(saber-plugin-image): remove blendIn class when image is loaded

### DIFF
--- a/packages/saber-plugin-image/lib/saber-browser.js
+++ b/packages/saber-plugin-image/lib/saber-browser.js
@@ -14,9 +14,12 @@ export default ({ Vue }) => {
       if ($el.dataset.src || $el.dataset.srcset) {
         lozad($el, {
           loaded: el => {
-            this.removeBlendIn = setTimeout(() => {
-              el.classList.remove(styles.blendIn)
-            }, 300)
+            el.addEventListener('load', () => {
+              el.setAttribute('data-lazy-loaded', '')
+              this.removeBlendIn = setTimeout(() => {
+                el.classList.remove(styles.blendIn)
+              }, 300)
+            })
           }
         }).observe()
       }

--- a/packages/saber-plugin-image/lib/saber-browser.js
+++ b/packages/saber-plugin-image/lib/saber-browser.js
@@ -13,14 +13,17 @@ export default ({ Vue }) => {
 
       if ($el.dataset.src || $el.dataset.srcset) {
         lozad($el, {
-          loaded(el) {
-            el.addEventListener(
-              'load',
-              () => el.setAttribute('data-lazy-loaded', ''),
-              { once: true }
-            )
+          loaded: el => {
+            this.removeBlendIn = setTimeout(() => {
+              el.classList.remove(styles.blendIn)
+            }, 300)
           }
         }).observe()
+      }
+    },
+    beforeDestroy() {
+      if (this.removeBlendIn) {
+        clearTimeout(this.removeBlendIn)
       }
     },
     render(h) {

--- a/packages/saber-plugin-image/lib/styles.module.css
+++ b/packages/saber-plugin-image/lib/styles.module.css
@@ -4,6 +4,6 @@
   filter: blur(5px);
 }
 
-.blendIn[data-loaded="true"] {
+.blendIn[data-lazy-loaded] {
   filter: none;
 }

--- a/packages/saber-plugin-image/lib/styles.module.css
+++ b/packages/saber-plugin-image/lib/styles.module.css
@@ -1,16 +1,6 @@
-.enter-active-class,
-.leave-active-class {
-  transition: opacity 0.3s;
-}
-
-.enter-class,
-.leave-to-class {
-  opacity: 0;
-}
-
 .blendIn[data-src],
 .blendIn[data-srcset] {
-  transition: filter 0.5s;
+  transition: filter 0.3s;
   filter: blur(5px);
 }
 

--- a/packages/saber-plugin-image/lib/styles.module.css
+++ b/packages/saber-plugin-image/lib/styles.module.css
@@ -1,6 +1,6 @@
 .enter-active-class,
 .leave-active-class {
-  transition: opacity 0.5s;
+  transition: opacity 0.3s;
 }
 
 .enter-class,

--- a/packages/saber-plugin-image/lib/styles.module.css
+++ b/packages/saber-plugin-image/lib/styles.module.css
@@ -14,6 +14,6 @@
   filter: blur(5px);
 }
 
-.blendIn[data-lazy-loaded] {
+.blendIn[data-loaded="true"] {
   filter: none;
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The `blendIn` class makes [medium-zoom](https://github.com/francoischalifour/medium-zoom) stop working

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE