### PR TITLE
refactor(saber-plugin-image): listening to `transitionend` instead of using `setTimeout`

### DIFF
--- a/packages/saber-plugin-image/lib/saber-browser.js
+++ b/packages/saber-plugin-image/lib/saber-browser.js
@@ -14,19 +14,22 @@ export default ({ Vue }) => {
       if ($el.dataset.src || $el.dataset.srcset) {
         lozad($el, {
           loaded: el => {
-            el.addEventListener('load', () => {
-              el.setAttribute('data-lazy-loaded', '')
-              this.removeBlendIn = setTimeout(() => {
-                el.classList.remove(styles.blendIn)
-              }, 300)
-            })
+            el.addEventListener(
+              'load',
+              () => {
+                el.setAttribute('data-lazy-loaded', '')
+                el.addEventListener(
+                  'transitionend',
+                  () => {
+                    el.classList.remove(styles.blendIn)
+                  },
+                  { once: true }
+                )
+              },
+              { once: true }
+            )
           }
         }).observe()
-      }
-    },
-    beforeDestroy() {
-      if (this.removeBlendIn) {
-        clearTimeout(this.removeBlendIn)
       }
     },
     render(h) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

https://github.com/saberland/saber/pull/390#discussion_r319050882

Listening to `transitionend` event when removing `blendIn` class instead of using inaccurate `setTimeout`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI/CSS related code, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
