### PR TITLE
fix(saber-plugin-pwa): show notifier before downloading app updates

### DIFF
--- a/packages/saber-plugin-pwa/README.md
+++ b/packages/saber-plugin-pwa/README.md
@@ -59,6 +59,7 @@ Use `siteConfig` in your Saber config file to configure the text:
 siteConfig:
   # Default values:
   pwaFirstTimeInstallMessage: Ready for offline use
+  pwaUpdateFoundMessage: Downloading app updates in the background..
   pwaUpdateReadyMessage: A new version of this app is available
   pwaUpdateButtonMessage: UPDATE
   pwaDismissMessage: DISMISS

--- a/packages/saber-plugin-pwa/lib/saber-browser.js
+++ b/packages/saber-plugin-pwa/lib/saber-browser.js
@@ -4,6 +4,8 @@ export default context => {
   if (process.browser && 'serviceWorker' in navigator) {
     const { notifyUpdates } = __PWA_OPTIONS__
     const { Workbox } = require('workbox-window')
+    const { createSnackbar } = require('@snackbar/core')
+    require('@snackbar/core/dist/snackbar.css')
 
     context.rootOptions.mixins.push({
       mounted() {
@@ -12,9 +14,6 @@ export default context => {
         ))
 
         if (notifyUpdates) {
-          const { createSnackbar } = require('@snackbar/core')
-          require('@snackbar/core/dist/snackbar.css')
-
           const {
             pwaFirstTimeInstallMessage = 'Ready for offline use',
             pwaUpdateFoundMessage = 'Downloading app updates in the background..',

--- a/packages/saber-plugin-pwa/lib/saber-browser.js
+++ b/packages/saber-plugin-pwa/lib/saber-browser.js
@@ -14,7 +14,7 @@ export default context => {
         let snackbar
         const {
           pwaFirstTimeInstallMessage = 'Ready for offline use',
-          pwaUpdateFoundMessage = 'Downloading app updates in the background..',
+          pwaUpdateFoundMessage = 'Downloading app updates in the background',
           pwaUpdateReadyMessage = 'A new version of this app is available',
           pwaUpdateButtonMessage = 'UPDATE',
           pwaDismissMessage = 'DISMISS'

--- a/packages/saber-plugin-pwa/lib/saber-browser.js
+++ b/packages/saber-plugin-pwa/lib/saber-browser.js
@@ -68,18 +68,23 @@ export default context => {
           })
         }
 
+        const hasInstalledWorker = Boolean(navigator.serviceWorker.controller)
+
         workbox.register().then(reg => {
           if (notifyUpdates) {
             reg.addEventListener('updatefound', () => {
-              snackbar.createSnackbar(pwaUpdateFoundMessage, {
-                position: 'right',
-                timeout: 3000,
-                actions: [
-                  {
-                    text: pwaDismissMessage
-                  }
-                ]
-              })
+              // `updatefound` is fired on first install too
+              if (hasInstalledWorker) {
+                snackbar.createSnackbar(pwaUpdateFoundMessage, {
+                  position: 'right',
+                  timeout: 3000,
+                  actions: [
+                    {
+                      text: pwaDismissMessage
+                    }
+                  ]
+                })
+              }
             })
           }
         })

--- a/packages/saber-plugin-pwa/lib/saber-browser.js
+++ b/packages/saber-plugin-pwa/lib/saber-browser.js
@@ -17,10 +17,11 @@ export default context => {
 
           const {
             pwaFirstTimeInstallMessage = 'Ready for offline use',
+            pwaUpdateFoundMessage = 'Downloading app updates in the background..',
             pwaUpdateReadyMessage = 'A new version of this app is available',
             pwaUpdateButtonMessage = 'UPDATE',
             pwaDismissMessage = 'DISMISS'
-           } = this.$siteConfig
+          } = this.$siteConfig
 
           const showUpdateNotifier = () => {
             createSnackbar(pwaUpdateReadyMessage, {
@@ -66,7 +67,19 @@ export default context => {
           })
         }
 
-        workbox.register()
+        workbox.register().then(reg => {
+          reg.addEventListener('updatefound', () => {
+            createSnackbar(pwaUpdateFoundMessage, {
+              position: 'right',
+              timeout: 3000,
+              actions: [
+                {
+                  text: pwaDismissMessage
+                }
+              ]
+            })
+          })
+        })
       }
     })
   }


### PR DESCRIPTION
Sometimes installing service worker might take a while, it's better to show a notifier before that to inform user that it's downloading in the background.