### PR TITLE
fix: generate unique client id

### DIFF
--- a/packages/saber/vue-renderer/app/dev-client.js
+++ b/packages/saber/vue-renderer/app/dev-client.js
@@ -1,8 +1,12 @@
 import client from 'webpack-hot-middleware/client'
 
 export const init = ({ router }) => {
+  window.__SABER_DEV_CLIENT_ID__ = Math.random()
+    .toString(36)
+    .substring(7)
+
   client.subscribe(obj => {
-    if (obj.action === 'router:push') {
+    if (obj.action === 'router:push' && obj.id === __SABER_DEV_CLIENT_ID__) {
       if (obj.error) {
         console.error(`You need to refresh the page when the error is fixed!`)
       }

--- a/packages/saber/vue-renderer/app/router.js
+++ b/packages/saber/vue-renderer/app/router.js
@@ -96,7 +96,7 @@ export default () => {
       next(false)
 
       visitedRoutes[to.path] = true
-      fetch('/_saber/visit-page?route=' + encodeURIComponent(to.fullPath))
+      fetch(`/_saber/visit-page?id=${window.__SABER_DEV_CLIENT_ID__}&route=${encodeURIComponent(to.fullPath)}`)
     })
 
     router.afterEach(() => {

--- a/packages/saber/vue-renderer/lib/index.js
+++ b/packages/saber/vue-renderer/lib/index.js
@@ -432,13 +432,18 @@ class VueRenderer {
       res.end()
 
       if (this.builtRoutes.has(pathname)) {
-        hotMiddleware.publish({ action: 'router:push', route: fullPath })
+        hotMiddleware.publish({
+          action: 'router:push',
+          route: fullPath,
+          id: req.query.id
+        })
       } else {
         event.once('done', error => {
           this.builtRoutes.add(pathname)
           hotMiddleware.publish({
             action: 'router:push',
             route: fullPath,
+            id: req.query.id,
             error
           })
         })


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The problem: In `--lazy` mode when you have multiple tabs opened, if you click a page link then all the tabs will be navigated the that page.

The solution: Assign a unique (roughly) id to each tab.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
